### PR TITLE
README書き換え時に改行を挿入する

### DIFF
--- a/Sources/DependenciesGraph/DependenciesGraph.swift
+++ b/Sources/DependenciesGraph/DependenciesGraph.swift
@@ -50,7 +50,7 @@ struct DependenciesGraph: ParsableCommand {
             throw DependenciesGraphError.failedToDecodeReadme
         }
         let removedReadme = ReadmeReader.removeLines(readme, from: "## Package Dependencies")
-        readme = removedReadme + readmeTitle + "\n" + mermaid
+        readme = removedReadme + readmeTitle + "\n" + mermaid + "\n"
         try readme.write(to: url, atomically: true, encoding: .utf8)
         print("✅ Updated README.md")
     }


### PR DESCRIPTION
`--add-to-readme`オプションを利用した際に、READMEを書き換え最後に改行が入ってないようです。

なぜ気づいたかというと、このリポジトリの[README](https://github.com/Ryu0118/swift-dependencies-graph/blob/main/README.md)（改行あり）に対して`swift run -c release dgraph . --add-to-readme`をすると、最後の行の改行を消してしまっています。
