### PR TITLE
fix: fetch products from spm dump json

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,9 @@ let package = Package(
             name: "DependenciesGraphCoreTests",
             dependencies: ["DependenciesGraphCore"],
             resources: [
-                .copy("Resources/dump_package.json")
+                .copy("Resources/dump_package.json"),
+                .copy("Resources/dump_package_by_name.json"),
+                .copy("Resources/dump_package_mix.json")
             ]
         ),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,10 @@ let package = Package(
         .target(name: "DependenciesGraphCore"),
         .testTarget(
             name: "DependenciesGraphCoreTests",
-            dependencies: ["DependenciesGraphCore"]
+            dependencies: ["DependenciesGraphCore"],
+            resources: [
+                .copy("Resources/dump_package.json")
+            ]
         ),
     ]
 )

--- a/Sources/DependenciesGraphCore/DependenciesReader.swift
+++ b/Sources/DependenciesGraphCore/DependenciesReader.swift
@@ -6,8 +6,12 @@ public protocol DumpPackage {
     ) throws -> String
 }
 
-struct DumpPackageDefault: DumpPackage {
-    func dumpPackage(
+extension DumpPackage where Self == DumpPackageDefault {
+    public static var `default`: any DumpPackage { DumpPackageDefault() }
+}
+
+public struct DumpPackageDefault: DumpPackage {
+    public func dumpPackage(
         packageRootDirectoryPath: String? = nil
     ) throws -> String {
         try Command.run(
@@ -21,12 +25,12 @@ struct DumpPackageDefault: DumpPackage {
 public struct DependenciesReader {
     private let packageRootDirectoryPath: String
     private let decoder: JSONDecoder
-    private let dumpPackage: DumpPackage
+    private let dumpPackage: any DumpPackage
 
     public init(
         packageRootDirectoryPath: String,
         decoder: JSONDecoder = .init(),
-        dumpPackage: DumpPackage = MermaidCreator.makeDefaultDumpPackage()
+        dumpPackage: any DumpPackage = .default
     ) {
         self.packageRootDirectoryPath = packageRootDirectoryPath
         self.decoder = decoder
@@ -54,6 +58,31 @@ package struct DumpPackageResponse: Decodable {
         struct Dependency: Decodable {
             let target: [String?]?
             let product: [String?]?
+            let byName: [String?]?
+
+            private enum CodingKeys: String, CodingKey {
+                case target
+                case product
+                case byName
+            }
+
+            init(target: [String?]?, product: [String?]?, byName: [String?]? = nil) {
+                // Normalize so that `target` and `byName` always reflect the same underlying value.
+                let effectiveByName = byName ?? target
+                self.byName = effectiveByName
+                self.target = effectiveByName
+                self.product = product
+            }
+
+            init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                let decodedTarget = try container.decodeIfPresent([String?].self, forKey: .target)
+                let decodedByName = try container.decodeIfPresent([String?].self, forKey: .byName)
+                let effectiveByName = decodedByName ?? decodedTarget
+                self.byName = effectiveByName
+                self.target = effectiveByName
+                self.product = try container.decodeIfPresent([String?].self, forKey: .product)
+            }
         }
     }
 }
@@ -61,10 +90,10 @@ package struct DumpPackageResponse: Decodable {
 extension DumpPackageResponse {
     func toModule(isIncludeProduct: Bool) -> [Module] {
         targets.map { target in
-            let byNameDependencies = target.dependencies.compactMap { $0.target?.compactMap(\.self).first }
-            let productDependencies = target.dependencies.compactMap { $0.product?.compactMap(\.self).first }
+            let byNameDependencies = target.dependencies.compactMap { $0.byName?.compactMap(\.self).first }.sorted()
+            let productDependencies = target.dependencies.compactMap { $0.product?.compactMap(\.self).first }.sorted()
             let dependencies = isIncludeProduct ? byNameDependencies + productDependencies : byNameDependencies
             return Module(name: target.name, dependencies: dependencies)
-        }
+        }.sorted { $0.name < $1.name }
     }
 }

--- a/Sources/DependenciesGraphCore/DependenciesReader.swift
+++ b/Sources/DependenciesGraphCore/DependenciesReader.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public protocol DumpPackage {
+public protocol DumpPackage: Sendable {
     func dumpPackage(
         packageRootDirectoryPath: String?
     ) throws -> String
@@ -48,7 +48,7 @@ public struct DependenciesReader {
     }
 }
 
-package struct DumpPackageResponse: Decodable {
+struct DumpPackageResponse: Decodable {
     let targets: [Target]
 
     struct Target: Decodable {

--- a/Sources/DependenciesGraphCore/DependenciesReader.swift
+++ b/Sources/DependenciesGraphCore/DependenciesReader.swift
@@ -1,26 +1,15 @@
 import Foundation
 
-public struct DependenciesReader {
-    private let packageRootDirectoryPath: String
-    private let decoder: JSONDecoder
+public protocol DumpPackage {
+    func dumpPackage(
+        packageRootDirectoryPath: String?
+    ) throws -> String
+}
 
-    public init(
-        packageRootDirectoryPath: String,
-        decoder: JSONDecoder = .init()
-    ) {
-        self.packageRootDirectoryPath = packageRootDirectoryPath
-        self.decoder = decoder
-    }
-
-    public func readDependencies(isIncludeProduct: Bool) throws -> [Module] {
-        let jsonString = try dumpPackage()
-        let jsonData = jsonString.data(using: .utf8)!
-        return try decoder
-            .decode(DumpPackageResponse.self, from: jsonData)
-            .toModule(isIncludeProduct: isIncludeProduct)
-    }
-
-    private func dumpPackage() throws -> String {
+struct DumpPackageDefault: DumpPackage {
+    func dumpPackage(
+        packageRootDirectoryPath: String? = nil
+    ) throws -> String {
         try Command.run(
             launchPath: "/usr/bin/env",
             currentDirectoryPath: packageRootDirectoryPath,
@@ -29,7 +18,33 @@ public struct DependenciesReader {
     }
 }
 
-private struct DumpPackageResponse: Decodable {
+public struct DependenciesReader {
+    private let packageRootDirectoryPath: String
+    private let decoder: JSONDecoder
+    private let dumpPackage: DumpPackage
+
+    public init(
+        packageRootDirectoryPath: String,
+        decoder: JSONDecoder = .init(),
+        dumpPackage: DumpPackage = MermaidCreator.makeDefaultDumpPackage()
+    ) {
+        self.packageRootDirectoryPath = packageRootDirectoryPath
+        self.decoder = decoder
+        self.dumpPackage = dumpPackage
+    }
+
+    public func readDependencies(isIncludeProduct: Bool) throws -> [Module] {
+        let jsonString = try dumpPackage.dumpPackage(
+            packageRootDirectoryPath: packageRootDirectoryPath
+        )
+        let jsonData = jsonString.data(using: .utf8)!
+        return try decoder
+            .decode(DumpPackageResponse.self, from: jsonData)
+            .toModule(isIncludeProduct: isIncludeProduct)
+    }
+}
+
+package struct DumpPackageResponse: Decodable {
     let targets: [Target]
 
     struct Target: Decodable {
@@ -37,7 +52,7 @@ private struct DumpPackageResponse: Decodable {
         let dependencies: [Dependency]
 
         struct Dependency: Decodable {
-            let byName: [String?]?
+            let target: [String?]?
             let product: [String?]?
         }
     }
@@ -46,7 +61,7 @@ private struct DumpPackageResponse: Decodable {
 extension DumpPackageResponse {
     func toModule(isIncludeProduct: Bool) -> [Module] {
         targets.map { target in
-            let byNameDependencies = target.dependencies.compactMap { $0.byName?.compactMap(\.self).first }
+            let byNameDependencies = target.dependencies.compactMap { $0.target?.compactMap(\.self).first }
             let productDependencies = target.dependencies.compactMap { $0.product?.compactMap(\.self).first }
             let dependencies = isIncludeProduct ? byNameDependencies + productDependencies : byNameDependencies
             return Module(name: target.name, dependencies: dependencies)

--- a/Sources/DependenciesGraphCore/MermaidCreator.swift
+++ b/Sources/DependenciesGraphCore/MermaidCreator.swift
@@ -19,6 +19,10 @@ public enum MermaidCreator {
             .appending("```")
             .joined(separator: "\n")
     }
+    
+    public static func makeDefaultDumpPackage() -> any DumpPackage {
+        DumpPackageDefault()
+    }
 
     private static func stripTransitiveDependencies(
         _ modules: [Module]

--- a/Sources/DependenciesGraphCore/MermaidCreator.swift
+++ b/Sources/DependenciesGraphCore/MermaidCreator.swift
@@ -19,10 +19,6 @@ public enum MermaidCreator {
             .appending("```")
             .joined(separator: "\n")
     }
-    
-    public static func makeDefaultDumpPackage() -> any DumpPackage {
-        DumpPackageDefault()
-    }
 
     private static func stripTransitiveDependencies(
         _ modules: [Module]

--- a/Tests/DependenciesGraphCoreTests/Extensions/Bundle+Extensions.swift
+++ b/Tests/DependenciesGraphCoreTests/Extensions/Bundle+Extensions.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+extension Bundle {
+    func data(
+        forResource name: String,
+        withExtension ext: String,
+        options: Data.ReadingOptions = []
+    ) throws -> Data {
+        guard let url = url(forResource: name, withExtension: ext) else {
+            throw NSError(domain: bundleIdentifier ?? "", code: NSFileReadNoSuchFileError)
+        }
+
+        return try Data(contentsOf: url)
+    }
+}
+
+extension Bundle {
+    public func json<T: Decodable>(
+        _ type: T.Type,
+        forResource name: String,
+        withExtension ext: String = "json",
+        decodable: JSONDecoder = .init()
+    ) throws -> T {
+        let data = try data(forResource: name, withExtension: ext, options: .mappedIfSafe)
+        return try decodable.decode(
+            type,
+            from: data
+        )
+    }
+}

--- a/Tests/DependenciesGraphCoreTests/Extensions/Bundle+Extensions.swift
+++ b/Tests/DependenciesGraphCoreTests/Extensions/Bundle+Extensions.swift
@@ -10,6 +10,6 @@ extension Bundle {
             throw NSError(domain: bundleIdentifier ?? "", code: NSFileReadNoSuchFileError)
         }
 
-        return try Data(contentsOf: url)
+        return try Data(contentsOf: url, options: options)
     }
 }

--- a/Tests/DependenciesGraphCoreTests/Extensions/Bundle+Extensions.swift
+++ b/Tests/DependenciesGraphCoreTests/Extensions/Bundle+Extensions.swift
@@ -13,18 +13,3 @@ extension Bundle {
         return try Data(contentsOf: url)
     }
 }
-
-extension Bundle {
-    public func json<T: Decodable>(
-        _ type: T.Type,
-        forResource name: String,
-        withExtension ext: String = "json",
-        decodable: JSONDecoder = .init()
-    ) throws -> T {
-        let data = try data(forResource: name, withExtension: ext, options: .mappedIfSafe)
-        return try decodable.decode(
-            type,
-            from: data
-        )
-    }
-}

--- a/Tests/DependenciesGraphCoreTests/MermaidFromDump.swift
+++ b/Tests/DependenciesGraphCoreTests/MermaidFromDump.swift
@@ -1,0 +1,55 @@
+@testable import DependenciesGraphCore
+import Testing
+import Foundation
+
+struct MermaidFromDumpTests {
+    
+    @Test func createMermaid() throws {
+        let dump = try Bundle.module.data(forResource: "dump_package", withExtension: "json")
+        let dumpPackage = DumpPackageMock()
+        dumpPackage.dumpPackagePackageRootDirectoryPathReturnValue = String(data: dump, encoding: .utf8)
+        
+        let sut = DependenciesReader(
+            packageRootDirectoryPath: "",
+            decoder: JSONDecoder(),
+            dumpPackage: dumpPackage
+        )
+        let modules = try sut.readDependencies(isIncludeProduct: false)
+        let result = MermaidCreator.create(from: modules, stripTransitive: false)
+        let expected = """
+        ```mermaid
+        graph TD;
+            ReduxKitUI-->ReduxKit;
+            ReduxKitExtensions-->ReduxKit;
+            ExampleApp-->ReduxKit;
+        ```
+        """
+
+        #expect(result == expected)
+    }
+    
+    @Test func createMermaidWithIncludedProduct() throws {
+        let dump = try Bundle.module.data(forResource: "dump_package", withExtension: "json")
+        let dumpPackage = DumpPackageMock()
+        dumpPackage.dumpPackagePackageRootDirectoryPathReturnValue = String(data: dump, encoding: .utf8)
+        
+        let sut = DependenciesReader(
+            packageRootDirectoryPath: "",
+            decoder: JSONDecoder(),
+            dumpPackage: dumpPackage
+        )
+        let modules = try sut.readDependencies(isIncludeProduct: true)
+        let result = MermaidCreator.create(from: modules, stripTransitive: true)
+        let expected = """
+        ```mermaid
+        graph TD;
+            ReduxKitUI-->ReduxKit;
+            ReduxKitExtensions-->Collections;
+            ReduxKitExtensions-->ReduxKit;
+            ExampleApp-->ReduxKit;
+        ```
+        """
+
+        #expect(result == expected)
+    }
+}

--- a/Tests/DependenciesGraphCoreTests/MermaidFromDump.swift
+++ b/Tests/DependenciesGraphCoreTests/MermaidFromDump.swift
@@ -3,53 +3,65 @@ import Testing
 import Foundation
 
 struct MermaidFromDumpTests {
-    
-    @Test func createMermaid() throws {
-        let dump = try Bundle.module.data(forResource: "dump_package", withExtension: "json")
-        let dumpPackage = DumpPackageMock()
-        dumpPackage.dumpPackagePackageRootDirectoryPathReturnValue = String(data: dump, encoding: .utf8)
-        
-        let sut = DependenciesReader(
-            packageRootDirectoryPath: "",
-            decoder: JSONDecoder(),
-            dumpPackage: dumpPackage
-        )
-        let modules = try sut.readDependencies(isIncludeProduct: false)
-        let result = MermaidCreator.create(from: modules, stripTransitive: false)
-        let expected = """
-        ```mermaid
-        graph TD;
-            ReduxKitUI-->ReduxKit;
-            ReduxKitExtensions-->ReduxKit;
-            ExampleApp-->ReduxKit;
-        ```
-        """
-
-        #expect(result == expected)
+    enum MermaidFromDumpTestsError: Error {
+        case invalidUTF8Dump
     }
     
-    @Test func createMermaidWithIncludedProduct() throws {
-        let dump = try Bundle.module.data(forResource: "dump_package", withExtension: "json")
+    struct TestCase {
+        let isIncludeProduct: Bool
+        let expected: String
+        
+        static let withoutProducts = TestCase(
+            isIncludeProduct: false,
+            expected: """
+                ```mermaid
+                graph TD;
+                    ExampleApp-->ReduxKit;
+                    ReduxKitExtensions-->ReduxKit;
+                    ReduxKitExtensionsTests-->ReduxKitExtensions;
+                    ReduxKitTests-->ReduxKit;
+                    ReduxKitUI-->ReduxKit;
+                ```
+                """
+        )
+        
+        static let withProducts = TestCase(
+            isIncludeProduct: true,
+            expected: """
+                ```mermaid
+                graph TD;
+                    ExampleApp-->ReduxKit;
+                    ReduxKitExtensions-->ReduxKit;
+                    ReduxKitExtensions-->Collections;
+                    ReduxKitExtensionsTests-->ReduxKitExtensions;
+                    ReduxKitTests-->ReduxKit;
+                    ReduxKitUI-->ReduxKit;
+                ```
+                """
+        )
+    }
+        
+    static let resources = ["dump_package", "dump_package_by_name", "dump_package_mix"]
+    static let testCases = [TestCase.withProducts, .withoutProducts]
+    
+    @Test(arguments: resources, testCases)
+    func createMermaid(resource: String, testCase: TestCase) throws {
+        let dump = try Bundle.module.data(forResource: resource, withExtension: "json")
+        guard let dumpString = String(data: dump, encoding: .utf8) else {
+            Issue.record("Invalid UTF8 dump")
+            throw MermaidFromDumpTestsError.invalidUTF8Dump
+        }
         let dumpPackage = DumpPackageMock()
-        dumpPackage.dumpPackagePackageRootDirectoryPathReturnValue = String(data: dump, encoding: .utf8)
+        dumpPackage.dumpPackagePackageRootDirectoryPathReturnValue = dumpString
         
         let sut = DependenciesReader(
             packageRootDirectoryPath: "",
             decoder: JSONDecoder(),
             dumpPackage: dumpPackage
         )
-        let modules = try sut.readDependencies(isIncludeProduct: true)
-        let result = MermaidCreator.create(from: modules, stripTransitive: true)
-        let expected = """
-        ```mermaid
-        graph TD;
-            ReduxKitUI-->ReduxKit;
-            ReduxKitExtensions-->Collections;
-            ReduxKitExtensions-->ReduxKit;
-            ExampleApp-->ReduxKit;
-        ```
-        """
-
-        #expect(result == expected)
+        let modules = try sut.readDependencies(isIncludeProduct: testCase.isIncludeProduct)
+        let result = MermaidCreator.create(from: modules, stripTransitive: false)
+        
+        #expect(result == testCase.expected)
     }
 }

--- a/Tests/DependenciesGraphCoreTests/MermaidFromDump.swift
+++ b/Tests/DependenciesGraphCoreTests/MermaidFromDump.swift
@@ -51,8 +51,7 @@ struct MermaidFromDumpTests {
             Issue.record("Invalid UTF8 dump")
             throw MermaidFromDumpTestsError.invalidUTF8Dump
         }
-        let dumpPackage = DumpPackageMock()
-        dumpPackage.dumpPackagePackageRootDirectoryPathReturnValue = dumpString
+        let dumpPackage = DumpPackageMock(dumpPackageReturnValue: dumpString)
         
         let sut = DependenciesReader(
             packageRootDirectoryPath: "",

--- a/Tests/DependenciesGraphCoreTests/Mock/DumpPackageMock.swift
+++ b/Tests/DependenciesGraphCoreTests/Mock/DumpPackageMock.swift
@@ -1,5 +1,9 @@
 import DependenciesGraphCore
 
+enum DumpPackageMockError: Error {
+    case missingReturnValue
+}
+
 final class DumpPackageMock: DumpPackage {
     
    // MARK: - dumpPackage
@@ -11,7 +15,7 @@ final class DumpPackageMock: DumpPackage {
     }
     var dumpPackagePackageRootDirectoryPathReceivedPackageRootDirectoryPath: String?
     var dumpPackagePackageRootDirectoryPathReceivedInvocations: [String?] = []
-    var dumpPackagePackageRootDirectoryPathReturnValue: String!
+    var dumpPackagePackageRootDirectoryPathReturnValue: String?
     var dumpPackagePackageRootDirectoryPathClosure: ((String?) throws -> String)?
 
     func dumpPackage(packageRootDirectoryPath: String?) throws -> String {
@@ -21,6 +25,13 @@ final class DumpPackageMock: DumpPackage {
         dumpPackagePackageRootDirectoryPathCallsCount += 1
         dumpPackagePackageRootDirectoryPathReceivedPackageRootDirectoryPath = packageRootDirectoryPath
         dumpPackagePackageRootDirectoryPathReceivedInvocations.append(packageRootDirectoryPath)
-        return try dumpPackagePackageRootDirectoryPathClosure.map({ try $0(packageRootDirectoryPath) }) ?? dumpPackagePackageRootDirectoryPathReturnValue
+
+        if let closure = dumpPackagePackageRootDirectoryPathClosure {
+            return try closure(packageRootDirectoryPath)
+        }
+        if let returnValue = dumpPackagePackageRootDirectoryPathReturnValue {
+            return returnValue
+        }
+        throw DumpPackageMockError.missingReturnValue
     }
 }

--- a/Tests/DependenciesGraphCoreTests/Mock/DumpPackageMock.swift
+++ b/Tests/DependenciesGraphCoreTests/Mock/DumpPackageMock.swift
@@ -1,37 +1,16 @@
 import DependenciesGraphCore
 
-enum DumpPackageMockError: Error {
-    case missingReturnValue
-}
-
-final class DumpPackageMock: DumpPackage {
+struct DumpPackageMock: DumpPackage {
     
-   // MARK: - dumpPackage
+    // MARK: - dumpPackage
 
-    var dumpPackagePackageRootDirectoryPathThrowableError: Error?
-    var dumpPackagePackageRootDirectoryPathCallsCount = 0
-    var dumpPackagePackageRootDirectoryPathCalled: Bool {
-        dumpPackagePackageRootDirectoryPathCallsCount > 0
+    private let dumpPackageReturnValue: String
+
+    init(dumpPackageReturnValue: String) {
+        self.dumpPackageReturnValue = dumpPackageReturnValue
     }
-    var dumpPackagePackageRootDirectoryPathReceivedPackageRootDirectoryPath: String?
-    var dumpPackagePackageRootDirectoryPathReceivedInvocations: [String?] = []
-    var dumpPackagePackageRootDirectoryPathReturnValue: String?
-    var dumpPackagePackageRootDirectoryPathClosure: ((String?) throws -> String)?
 
     func dumpPackage(packageRootDirectoryPath: String?) throws -> String {
-        if let error = dumpPackagePackageRootDirectoryPathThrowableError {
-            throw error
-        }
-        dumpPackagePackageRootDirectoryPathCallsCount += 1
-        dumpPackagePackageRootDirectoryPathReceivedPackageRootDirectoryPath = packageRootDirectoryPath
-        dumpPackagePackageRootDirectoryPathReceivedInvocations.append(packageRootDirectoryPath)
-
-        if let closure = dumpPackagePackageRootDirectoryPathClosure {
-            return try closure(packageRootDirectoryPath)
-        }
-        if let returnValue = dumpPackagePackageRootDirectoryPathReturnValue {
-            return returnValue
-        }
-        throw DumpPackageMockError.missingReturnValue
+        dumpPackageReturnValue
     }
 }

--- a/Tests/DependenciesGraphCoreTests/Mock/DumpPackageMock.swift
+++ b/Tests/DependenciesGraphCoreTests/Mock/DumpPackageMock.swift
@@ -1,0 +1,26 @@
+import DependenciesGraphCore
+
+final class DumpPackageMock: DumpPackage {
+    
+   // MARK: - dumpPackage
+
+    var dumpPackagePackageRootDirectoryPathThrowableError: Error?
+    var dumpPackagePackageRootDirectoryPathCallsCount = 0
+    var dumpPackagePackageRootDirectoryPathCalled: Bool {
+        dumpPackagePackageRootDirectoryPathCallsCount > 0
+    }
+    var dumpPackagePackageRootDirectoryPathReceivedPackageRootDirectoryPath: String?
+    var dumpPackagePackageRootDirectoryPathReceivedInvocations: [String?] = []
+    var dumpPackagePackageRootDirectoryPathReturnValue: String!
+    var dumpPackagePackageRootDirectoryPathClosure: ((String?) throws -> String)?
+
+    func dumpPackage(packageRootDirectoryPath: String?) throws -> String {
+        if let error = dumpPackagePackageRootDirectoryPathThrowableError {
+            throw error
+        }
+        dumpPackagePackageRootDirectoryPathCallsCount += 1
+        dumpPackagePackageRootDirectoryPathReceivedPackageRootDirectoryPath = packageRootDirectoryPath
+        dumpPackagePackageRootDirectoryPathReceivedInvocations.append(packageRootDirectoryPath)
+        return try dumpPackagePackageRootDirectoryPathClosure.map({ try $0(packageRootDirectoryPath) }) ?? dumpPackagePackageRootDirectoryPathReturnValue
+    }
+}

--- a/Tests/DependenciesGraphCoreTests/Resources/dump_package.json
+++ b/Tests/DependenciesGraphCoreTests/Resources/dump_package.json
@@ -1,0 +1,241 @@
+{
+  "cLanguageStandard" : null,
+  "cxxLanguageStandard" : null,
+  "dependencies" : [
+    {
+      "sourceControl" : [
+        {
+          "identity" : "swift-collections",
+          "location" : {
+            "remote" : [
+              {
+                "urlString" : "https://github.com/apple/swift-collections"
+              }
+            ]
+          },
+          "productFilter" : null,
+          "requirement" : {
+            "range" : [
+              {
+                "lowerBound" : "1.1.4",
+                "upperBound" : "2.0.0"
+              }
+            ]
+          },
+          "traits" : [
+            {
+              "name" : "default"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "name" : "redux-kit",
+  "pkgConfig" : null,
+  "platforms" : [
+    {
+      "options" : [
+
+      ],
+      "platformName" : "macos",
+      "version" : "14.0"
+    },
+    {
+      "options" : [
+
+      ],
+      "platformName" : "ios",
+      "version" : "17.0"
+    }
+  ],
+  "products" : [
+    {
+      "name" : "ReduxKit",
+      "settings" : [
+
+      ],
+      "targets" : [
+        "ReduxKit"
+      ],
+      "type" : {
+        "library" : [
+          "automatic"
+        ]
+      }
+    },
+    {
+      "name" : "ReduxKitExtensions",
+      "settings" : [
+
+      ],
+      "targets" : [
+        "ReduxKitExtensions"
+      ],
+      "type" : {
+        "library" : [
+          "automatic"
+        ]
+      }
+    },
+    {
+      "name" : "ReduxKitUI",
+      "settings" : [
+
+      ],
+      "targets" : [
+        "ReduxKitUI"
+      ],
+      "type" : {
+        "library" : [
+          "automatic"
+        ]
+      }
+    }
+  ],
+  "providers" : null,
+  "swiftLanguageVersions" : null,
+  "targets" : [
+    {
+      "dependencies" : [
+
+      ],
+      "exclude" : [
+
+      ],
+      "name" : "ReduxKit",
+      "packageAccess" : true,
+      "resources" : [
+
+      ],
+      "settings" : [
+
+      ],
+      "type" : "regular"
+    },
+    {
+      "dependencies" : [
+        {
+          "byName" : [
+            "ReduxKit",
+            null
+          ]
+        }
+      ],
+      "exclude" : [
+
+      ],
+      "name" : "ReduxKitTests",
+      "packageAccess" : true,
+      "resources" : [
+
+      ],
+      "settings" : [
+
+      ],
+      "type" : "test"
+    },
+    {
+      "dependencies" : [
+        {
+          "target" : [
+            "ReduxKit",
+            null
+          ]
+        }
+      ],
+      "exclude" : [
+
+      ],
+      "name" : "ReduxKitUI",
+      "packageAccess" : true,
+      "resources" : [
+
+      ],
+      "settings" : [
+
+      ],
+      "type" : "regular"
+    },
+    {
+      "dependencies" : [
+        {
+          "target" : [
+            "ReduxKit",
+            null
+          ]
+        },
+        {
+          "product" : [
+            "Collections",
+            "swift-collections",
+            null,
+            null
+          ]
+        }
+      ],
+      "exclude" : [
+
+      ],
+      "name" : "ReduxKitExtensions",
+      "packageAccess" : true,
+      "resources" : [
+
+      ],
+      "settings" : [
+
+      ],
+      "type" : "regular"
+    },
+    {
+      "dependencies" : [
+        {
+          "byName" : [
+            "ReduxKitExtensions",
+            null
+          ]
+        }
+      ],
+      "exclude" : [
+
+      ],
+      "name" : "ReduxKitExtensionsTests",
+      "packageAccess" : true,
+      "resources" : [
+
+      ],
+      "settings" : [
+
+      ],
+      "type" : "test"
+    },
+    {
+      "dependencies" : [
+        {
+          "target" : [
+            "ReduxKit",
+            null
+          ]
+        }
+      ],
+      "exclude" : [
+
+      ],
+      "name" : "ExampleApp",
+      "packageAccess" : true,
+      "resources" : [
+
+      ],
+      "settings" : [
+
+      ],
+      "type" : "executable"
+    }
+  ],
+  "toolsVersion" : {
+    "_version" : "6.0.0"
+  },
+  "traits" : [
+
+  ]
+}

--- a/Tests/DependenciesGraphCoreTests/Resources/dump_package_by_name.json
+++ b/Tests/DependenciesGraphCoreTests/Resources/dump_package_by_name.json
@@ -121,7 +121,7 @@
     {
       "dependencies" : [
         {
-          "target" : [
+          "byName" : [
             "ReduxKit",
             null
           ]
@@ -143,7 +143,7 @@
     {
       "dependencies" : [
         {
-          "target" : [
+          "byName" : [
             "ReduxKit",
             null
           ]
@@ -165,7 +165,7 @@
     {
       "dependencies" : [
         {
-          "target" : [
+          "byName" : [
             "ReduxKit",
             null
           ]
@@ -195,7 +195,7 @@
     {
       "dependencies" : [
         {
-          "target" : [
+          "byName" : [
             "ReduxKitExtensions",
             null
           ]
@@ -217,7 +217,7 @@
     {
       "dependencies" : [
         {
-          "target" : [
+          "byName" : [
             "ReduxKit",
             null
           ]

--- a/Tests/DependenciesGraphCoreTests/Resources/dump_package_mix.json
+++ b/Tests/DependenciesGraphCoreTests/Resources/dump_package_mix.json
@@ -32,11 +32,6 @@
     }
   ],
   "name" : "redux-kit",
-  "packageKind" : {
-    "root" : [
-      "/Users/amine/Developer/personal/gitlab/intech-consulting-app/swift-packages/redux-kit"
-    ]
-  },
   "pkgConfig" : null,
   "platforms" : [
     {
@@ -44,7 +39,7 @@
 
       ],
       "platformName" : "macos",
-      "version" : "15.0"
+      "version" : "14.0"
     },
     {
       "options" : [
@@ -121,7 +116,7 @@
     {
       "dependencies" : [
         {
-          "target" : [
+          "byName" : [
             "ReduxKit",
             null
           ]
@@ -195,7 +190,7 @@
     {
       "dependencies" : [
         {
-          "target" : [
+          "byName" : [
             "ReduxKitExtensions",
             null
           ]


### PR DESCRIPTION
## Description

When I use `reader.readDependencies` the json decoder not working because it's not find `byName` key on json then the `DumpPackageResponse.Target.Dependency` model not work

if have this result
```markdown
       ```mermaid
              graph TD;
       ```
```

when we replace `byName` with `target` the reader work and we have a correct mermaid markdown result.

my be it's caused by a change on `swift package dump_package` 